### PR TITLE
Add Next.js personal website skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _site/
+node_modules/
+.next/

--- a/README.md
+++ b/README.md
@@ -1,37 +1,27 @@
-## Welcome to GitHub Pages
+# Personal Website
 
-You can use the [editor on GitHub](https://github.com/zhangshushu15/zhangshushu15.github.com/edit/master/README.md) to maintain and preview the content for your website in Markdown files.
+This repository contains the source code for a simple personal website built with **Next.js** and **Tailwind CSS**. All project files live in the repository root.
 
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
+## Getting Started
 
-### Markdown
+1. Install dependencies (requires Node.js and npm):
+   ```bash
+   npm install
+   ```
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+3. Build for production:
+   ```bash
+   npm run build
+   npm start
+   ```
 
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
+## Project Structure
 
-```markdown
-Syntax highlighted code block
+- `pages/` – application pages
+- `components/` – reusable React components
+- `styles/` – global styles powered by Tailwind
 
-# Header 1
-## Header 2
-### Header 3
-
-- Bulleted
-- List
-
-1. Numbered
-2. List
-
-**Bold** and _Italic_ and `Code` text
-
-[Link](url) and ![Image](src)
-```
-
-For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
-
-### Jekyll Themes
-
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/zhangshushu15/zhangshushu15.github.com/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
-
-### Support or Contact
-
-Having trouble with Pages? Check out our [documentation](https://help.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.
+Feel free to customize the content under `pages/index.tsx` to suit your needs.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,13 @@
+export default function Header() {
+  return (
+    <header className="bg-white shadow w-full">
+      <nav className="container mx-auto px-4 py-4 flex justify-between">
+        <span className="font-bold">MySite</span>
+        <div>
+          <a className="mr-4 hover:underline" href="#about">About</a>
+          <a className="hover:underline" href="#contact">Contact</a>
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "personal-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.5",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.0.4",
+    "typescript": "^5.3.3"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,24 @@
+import Header from '../components/Header';
+import Head from 'next/head';
+
+export default function Home() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <Header />
+      <Head>
+        <title>My Personal Site</title>
+        <meta name="description" content="Personal website" />
+      </Head>
+      <main className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Hi, I'm John Doe</h1>
+        <p className="text-lg mb-8">Welcome to my personal website built with Next.js and Tailwind CSS.</p>
+        <a
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          href="https://github.com/"
+        >
+          Visit my GitHub
+        </a>
+      </main>
+    </div>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up a `personal-site` folder with a basic Next.js + Tailwind project
- replace README with instructions for running the Next.js site
- move Next.js project files from `personal-site` to repo root

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68697af77900832aade13ce534b70c4b