### PR TITLE
Add missing About and Contact pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal Website
 
-This repository contains the source code for a simple personal website built with **Next.js** and **Tailwind CSS**. The site includes basic sections like About and Contact and demonstrates how to structure a small project with reusable React components.
+This repository contains the source code for a simple personal website built with **Next.js** and **Tailwind CSS**. The site includes pages for About and Contact and demonstrates how to structure a small project with reusable React components.
 
 ## Getting Started
 
@@ -20,7 +20,7 @@ This repository contains the source code for a simple personal website built wit
 
 ## Project Structure
 
-- `pages/` – application pages
+- `pages/` – application pages (`index.tsx`, `about.tsx`, `contact.tsx`)
 - `components/` – reusable React components (Header and Footer)
 - `styles/` – global styles powered by Tailwind
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,8 +4,8 @@ export default function Header() {
       <nav className="container mx-auto px-4 py-4 flex justify-between">
         <span className="font-bold">MySite</span>
         <div>
-          <a className="mr-4 hover:underline" href="#about">About</a>
-          <a className="hover:underline" href="#contact">Contact</a>
+          <a className="mr-4 hover:underline" href="/about">About</a>
+          <a className="hover:underline" href="/contact">Contact</a>
         </div>
       </nav>
     </header>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,25 @@
+import Head from 'next/head';
+import Footer from '../components/Footer';
+import Header from '../components/Header';
+
+export default function About() {
+  return (
+    <div className="min-h-screen flex flex-col items-center">
+      <Head>
+        <title>About - John Doe</title>
+        <meta name="description" content="About John Doe" />
+      </Head>
+      <Header />
+      <main className="w-full max-w-3xl flex-grow mt-8">
+        <h1 className="text-3xl font-semibold mb-4">About Me</h1>
+        <p className="mb-4">
+          I'm a software developer who enjoys building web applications and learning new technologies.
+        </p>
+        <p>
+          <a href="/" className="text-blue-700 underline">Back to home</a>
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,26 @@
+import Head from 'next/head';
+import Footer from '../components/Footer';
+import Header from '../components/Header';
+
+export default function Contact() {
+  return (
+    <div className="min-h-screen flex flex-col items-center">
+      <Head>
+        <title>Contact - John Doe</title>
+        <meta name="description" content="Contact John Doe" />
+      </Head>
+      <Header />
+      <main className="w-full max-w-3xl flex-grow mt-8">
+        <h1 className="text-3xl font-semibold mb-4">Contact</h1>
+        <p className="mb-4">
+          You can reach me at{' '}
+          <a className="underline text-blue-700" href="mailto:john.doe@example.com">john.doe@example.com</a>.
+        </p>
+        <p>
+          <a href="/" className="text-blue-700 underline">Back to home</a>
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement About and Contact pages
- wire up navigation links in `Header`
- update README project description and structure

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869b2255dfc832a8d9c205adf5d09fa